### PR TITLE
Fix preproc string type check

### DIFF
--- a/dqn/NeuralQLearner.lua
+++ b/dqn/NeuralQLearner.lua
@@ -96,7 +96,7 @@ function nql:__init(args)
     end
 
     -- Load preprocessing network.
-    if not (type(self.preproc == 'string')) then
+    if not (type(self.preproc) == 'string') then
         error('The preprocessing is not a string')
     end
     msg, err = pcall(require, self.preproc)


### PR DESCRIPTION
Re-balance parentheses so the check actually occurs.
### [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)

I hereby waive my rights to this work worldwide under copyright law and all related or neighboring legal rights I had in the work, to the extent allowable by law.
